### PR TITLE
Readme : add the necessity of bzrlib

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -6,8 +6,16 @@ repositories as if they were Git ones:
 git clone "bzr::lp:ubuntu/hello"
 --------------------------------------
 
-To enable this, simply add the 'git-remote-bzr' script anywhere in your
-`$PATH`:
+== Installation ==
+
+* First check that the python library 'bzrlib' installed.
+If needed, run :
+
+--------------------------------------
+sudo aptitude install python-bzrlib
+--------------------------------------
+
+* Then, simply add the 'git-remote-bzr' script anywhere in your `$PATH`:
 
 --------------------------------------
 wget https://raw.github.com/felipec/git-remote-bzr/master/git-remote-bzr -O ~/bin/git-remote-bzr


### PR DESCRIPTION
When not developing in bazaar, bzrlib is not installed, and an error message is issued :
Traceback (most recent call last):
  File "/usr/local/bin/git-remote-bzr", line 25, in <module>
    import bzrlib
ImportError: No module named bzrlib

Don't hesitate to rephrase or cherry-pick rather than merging pull-request, if you find it necessary.