### PR TITLE
Filter out raw carriage returns from commit messages from git

### DIFF
--- a/git-remote-bzr
+++ b/git-remote-bzr
@@ -641,6 +641,9 @@ def parse_commit(parser):
     if data[-1] == '\n':
         data = data[:-1]
 
+    # bzr does not accept \r
+    data = data.replace('\r','')
+
     files = {}
 
     for line in parser:

--- a/test/main.t
+++ b/test/main.t
@@ -57,7 +57,9 @@ test_expect_success 'pushing' '
 	(
 	cd gitrepo &&
 	echo three > content &&
-	git commit -a -m three &&
+	echo "four\rno, three" > message &&
+	git commit -a -F message &&
+	rm -f message &&
 	git push
 	) &&
 


### PR DESCRIPTION
Contains test modification and fix. Of course, feel free to narrow the pull down to the fix, testing this isn't very elegant.