### PR TITLE
Add support for Breezy VCS

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -16,7 +16,7 @@ chmod +x ~/bin/git-remote-bzr
 
 That's it :)
 
-Obviously you will need Bazaar installed.
+Obviously you will need Breezy or Bazaar installed.
 
 == Notes ==
 

--- a/git-remote-bzr
+++ b/git-remote-bzr
@@ -22,7 +22,11 @@
 
 import sys
 
-import bzrlib
+try:
+    import breezy as bzrlib
+except ImportError:
+    import bzrlib
+
 if hasattr(bzrlib, "initialize"):
     bzrlib.initialize()
 


### PR DESCRIPTION
Prefer the breezy module over bzrlib as Canonical has abandoned Bazaar.

Import breezy as bzrlib to avoid having to change the rest of the code.

See-also: https://www.breezy-vcs.org/
Fixes: https://bugs.debian.org/923096
Fixes: https://github.com/felipec/git-remote-bzr/issues/27